### PR TITLE
Implement Task 04 UI structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,76 @@
     <link rel="stylesheet" href="./styles/style.css" />
 </head>
 <body>
-    <main></main>
+    <main class="app" data-app>
+        <header class="app__header" data-component="header">
+            <div class="app__header-main">
+                <h1 class="app__title">Othello</h1>
+                <p class="app__turn" data-current-player>現在の手番: -</p>
+            </div>
+            <dl class="scoreboard" data-scoreboard aria-label="スコア">
+                <div class="scoreboard__item scoreboard__item--black">
+                    <dt class="scoreboard__label">黒</dt>
+                    <dd class="scoreboard__value" data-score="black">0</dd>
+                </div>
+                <div class="scoreboard__item scoreboard__item--white">
+                    <dt class="scoreboard__label">白</dt>
+                    <dd class="scoreboard__value" data-score="white">0</dd>
+                </div>
+            </dl>
+        </header>
+
+        <section class="app__board" data-component="board" aria-label="オセロ盤">
+            <div class="board" role="grid" aria-label="オセロ盤" data-board></div>
+        </section>
+
+        <section class="app__controls" data-component="controls" aria-label="操作バー">
+            <button type="button" class="control-button" data-action="new-game">新規ゲーム</button>
+            <button type="button" class="control-button" data-action="switch-first-player">先手切替</button>
+            <button type="button" class="control-button" data-action="toggle-highlight">ハイライト切替</button>
+            <button type="button" class="control-button" data-action="undo">アンドゥ</button>
+        </section>
+
+        <footer class="app__footer" data-component="footer">
+            <small class="app__copyright">&copy; 2024 Othello Project</small>
+        </footer>
+
+        <dialog class="app-dialog" data-dialog="pass">
+            <form method="dialog" class="app-dialog__form">
+                <p class="app-dialog__message" data-pass-message>合法手がないため自動でパスしました。</p>
+                <menu class="app-dialog__actions">
+                    <button value="close" class="app-dialog__button" data-pass-close>OK</button>
+                </menu>
+            </form>
+        </dialog>
+
+        <dialog class="app-dialog" data-dialog="result">
+            <form method="dialog" class="app-dialog__form">
+                <header class="app-dialog__header">
+                    <h2 class="app-dialog__title">対局結果</h2>
+                </header>
+                <div class="app-dialog__body">
+                    <p class="app-dialog__summary" data-result-summary>勝敗情報がここに表示されます。</p>
+                    <dl class="app-dialog__scores">
+                        <div class="app-dialog__score app-dialog__score--black">
+                            <dt>黒</dt>
+                            <dd data-result-score="black">0</dd>
+                        </div>
+                        <div class="app-dialog__score app-dialog__score--white">
+                            <dt>白</dt>
+                            <dd data-result-score="white">0</dd>
+                        </div>
+                    </dl>
+                </div>
+                <menu class="app-dialog__actions">
+                    <button type="button" class="app-dialog__button" data-result-new-game>新規ゲーム</button>
+                    <button value="close" class="app-dialog__button">閉じる</button>
+                </menu>
+            </form>
+        </dialog>
+    </main>
     <script src="./scripts/game.js"></script>
+    <script src="./scripts/state.js"></script>
+    <script src="./scripts/ui.js"></script>
     <script src="./scripts/main.js"></script>
 </body>
 </html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,1 +1,36 @@
-// Entry point script placeholder. Game logic will be added in subsequent tasks.
+(function (global) {
+    'use strict';
+
+    const isCommonJs = typeof module !== 'undefined' && module.exports;
+    const StateModule = global.OthelloState || (isCommonJs ? require('./state.js') : null);
+    const UiModule = global.OthelloUI || (isCommonJs ? require('./ui.js') : null);
+
+    function bootstrap() {
+        if (!StateModule || !UiModule) {
+            console.error('Othello modules are not available.');
+            return null;
+        }
+        if (typeof document === 'undefined') {
+            return null;
+        }
+
+        const controller = StateModule.createGameController();
+        const ui = UiModule.createUI(controller);
+
+        const app = { controller, ui };
+        global.OthelloApp = app;
+        return app;
+    }
+
+    if (typeof document !== 'undefined') {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', bootstrap, { once: true });
+        } else {
+            bootstrap();
+        }
+    }
+
+    if (isCommonJs) {
+        module.exports = { bootstrap };
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -1,0 +1,201 @@
+(function (global) {
+    'use strict';
+
+    const CLASS_NAMES = Object.freeze({
+        boardRow: 'board__row',
+        boardCell: 'board__cell',
+        highlightEnabled: 'is-highlight-enabled',
+        cellHighlighted: 'is-highlighted'
+    });
+
+    function assertController(controller) {
+        if (!controller || typeof controller.getState !== 'function' || typeof controller.playMove !== 'function') {
+            throw new Error('A valid game controller must be provided to createUI.');
+        }
+    }
+
+    function ensureDomAvailable() {
+        if (typeof document === 'undefined') {
+            throw new Error('createUI requires a DOM environment.');
+        }
+    }
+
+    function toIndex(value) {
+        const parsed = Number.parseInt(value, 10);
+        return Number.isNaN(parsed) ? null : parsed;
+    }
+
+    function createCellElement(row, col) {
+        const cell = document.createElement('button');
+        cell.type = 'button';
+        cell.classList.add(CLASS_NAMES.boardCell);
+        cell.dataset.row = String(row);
+        cell.dataset.col = String(col);
+        cell.dataset.cell = 'true';
+        cell.setAttribute('role', 'gridcell');
+        cell.setAttribute('aria-label', `行${row + 1} 列${col + 1}`);
+        return cell;
+    }
+
+    function createRowElement(rowIndex, boardSize, cellGrid) {
+        const rowElement = document.createElement('div');
+        rowElement.classList.add(CLASS_NAMES.boardRow);
+        rowElement.setAttribute('role', 'row');
+
+        for (let col = 0; col < boardSize; col += 1) {
+            const cell = createCellElement(rowIndex, col);
+            rowElement.appendChild(cell);
+            cellGrid[rowIndex][col] = cell;
+        }
+
+        return rowElement;
+    }
+
+    function buildBoard(boardElement, boardSize) {
+        const cellGrid = Array.from({ length: boardSize }, () => Array(boardSize).fill(null));
+        boardElement.innerHTML = '';
+
+        for (let row = 0; row < boardSize; row += 1) {
+            boardElement.appendChild(createRowElement(row, boardSize, cellGrid));
+        }
+
+        return cellGrid;
+    }
+
+    function createUI(controller, options) {
+        assertController(controller);
+        ensureDomAvailable();
+
+        const config = options || {};
+        const root = config.root || document;
+        const mainElement = root.querySelector('main');
+        if (!mainElement) {
+            throw new Error('Main element not found.');
+        }
+
+        const boardElement = mainElement.querySelector('[data-board]');
+        if (!boardElement) {
+            throw new Error('Board element with data-board attribute not found.');
+        }
+
+        const initialState = controller.getState();
+        const boardSize = Array.isArray(initialState.board) ? initialState.board.length : 8;
+
+        boardElement.setAttribute('role', 'grid');
+        boardElement.setAttribute('aria-rowcount', String(boardSize));
+        boardElement.setAttribute('aria-colcount', String(boardSize));
+        boardElement.dataset.boardSize = String(boardSize);
+
+        const cellGrid = buildBoard(boardElement, boardSize);
+
+        function getCellElement(row, col) {
+            if (!Number.isInteger(row) || !Number.isInteger(col)) {
+                return null;
+            }
+            if (row < 0 || col < 0 || row >= cellGrid.length || col >= cellGrid[row].length) {
+                return null;
+            }
+            return cellGrid[row][col];
+        }
+
+        function clearHighlights() {
+            for (const row of cellGrid) {
+                for (const cell of row) {
+                    if (cell) {
+                        cell.classList.remove(CLASS_NAMES.cellHighlighted);
+                    }
+                }
+            }
+        }
+
+        function setCellHighlighted(row, col, highlighted) {
+            const cell = getCellElement(row, col);
+            if (!cell) {
+                return;
+            }
+            cell.classList.toggle(CLASS_NAMES.cellHighlighted, Boolean(highlighted));
+        }
+
+        function highlightCells(positions) {
+            clearHighlights();
+            if (!Array.isArray(positions)) {
+                return;
+            }
+            for (const position of positions) {
+                if (!position) {
+                    continue;
+                }
+                const rowIndex = toIndex(position.row);
+                const colIndex = toIndex(position.col);
+                if (rowIndex === null || colIndex === null) {
+                    continue;
+                }
+                setCellHighlighted(rowIndex, colIndex, true);
+            }
+        }
+
+        function setHighlightEnabled(enabled) {
+            boardElement.classList.toggle(CLASS_NAMES.highlightEnabled, Boolean(enabled));
+        }
+
+        function handleBoardClick(event) {
+            const target = event.target.closest('[data-cell]');
+            if (!target || !boardElement.contains(target)) {
+                return;
+            }
+            const row = toIndex(target.dataset.row);
+            const col = toIndex(target.dataset.col);
+            if (row === null || col === null) {
+                return;
+            }
+            controller.playMove(row, col);
+        }
+
+        boardElement.addEventListener('click', handleBoardClick);
+
+        const ui = {
+            elements: {
+                root: mainElement,
+                board: boardElement,
+                cells: cellGrid,
+                turnLabel: mainElement.querySelector('[data-current-player]'),
+                score: {
+                    black: mainElement.querySelector('[data-score="black"]'),
+                    white: mainElement.querySelector('[data-score="white"]')
+                },
+                controls: {
+                    newGame: mainElement.querySelector('[data-action="new-game"]'),
+                    switchFirstPlayer: mainElement.querySelector('[data-action="switch-first-player"]'),
+                    toggleHighlight: mainElement.querySelector('[data-action="toggle-highlight"]'),
+                    undo: mainElement.querySelector('[data-action="undo"]')
+                },
+                dialogs: {
+                    pass: root.querySelector('[data-dialog="pass"]'),
+                    result: root.querySelector('[data-dialog="result"]')
+                }
+            },
+            getCellElement,
+            clearHighlights,
+            setCellHighlighted,
+            highlightCells,
+            setHighlightEnabled,
+            destroy() {
+                boardElement.removeEventListener('click', handleBoardClick);
+            }
+        };
+
+        setHighlightEnabled(Boolean(initialState.settings && initialState.settings.highlightLegalMoves));
+
+        return ui;
+    }
+
+    const api = Object.freeze({
+        createUI
+    });
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    } else {
+        global.OthelloUI = api;
+    }
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- expand the main layout with header, board, controls, footer, and dialog shells for future interactions
- add a UI module that builds the 8×8 grid, wires cell clicks to the controller, and exposes highlight helpers
- bootstrap the application from main.js, instantiating the controller and UI once the DOM is ready

## Testing
- node -e "require('./scripts/main.js');"


------
https://chatgpt.com/codex/tasks/task_e_68cd783a4914832ab9100bb614037fc2