### PR TITLE
連続パス処理の改善

### DIFF
--- a/scripts/state.js
+++ b/scripts/state.js
@@ -119,9 +119,16 @@
                 return;
             }
 
+            if (state.scores && state.scores.empty === 0) {
+                state.currentPlayer = Game.getOpponent(previousPlayer);
+                state.legalMoves = [];
+                state.isGameOver = true;
+                return;
+            }
+
             let playerToCheck = Game.getOpponent(previousPlayer);
 
-            while (true) {
+            for (let attempt = 0; attempt < 2; attempt += 1) {
                 const legalMoves = Game.findLegalMoves(state.board, playerToCheck);
                 if (legalMoves.length > 0) {
                     state.currentPlayer = playerToCheck;
@@ -132,16 +139,12 @@
 
                 state.consecutivePasses += 1;
                 recordPass(playerToCheck);
-
-                if (state.consecutivePasses >= 2 || Game.isGameOver(state.board)) {
-                    state.currentPlayer = playerToCheck;
-                    state.legalMoves = [];
-                    state.isGameOver = true;
-                    return;
-                }
-
                 playerToCheck = Game.getOpponent(playerToCheck);
             }
+
+            state.currentPlayer = playerToCheck;
+            state.legalMoves = [];
+            state.isGameOver = true;
         }
 
         function getState() {


### PR DESCRIPTION
## Summary
- 盤面が埋まった場合にパス履歴を残さずに終局するよう `advanceTurn` を調整
- 自動パス時に両手番を順次確認し、連続パス回数と履歴を正しく管理

## Testing
- node scripts/game.js

------
https://chatgpt.com/codex/tasks/task_e_68d3b9151418832ab8f2213f9da57bed